### PR TITLE
Remove encode env

### DIFF
--- a/polyaxon_deploy/operators/kubectl.py
+++ b/polyaxon_deploy/operators/kubectl.py
@@ -35,7 +35,7 @@ class KubectlOperator(CmdOperator):
             PATH='{}:{}'.format(
                 polyaxon_user_path(),
                 env.get('PATH', ''),
-            ).encode(),
+            ),
         ))
         return env
 

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setup(name='polyaxon-deploy',
       tests_require=[
           "pytest",
           "httpretty==0.8.14",
-          "fake-factory==0.7.2"
+          "fake-factory==0.7.2",
+          "mock",
       ],
       cmdclass={'test': PyTest})


### PR DESCRIPTION
Using Python 3.7.3, `polyaxon deploy -f polyaxon_config.yaml --check` fails on Windows with the following error:

```
TypeError: environment can only contain strings
```

since the `env` argument for `Popen` on Windows has to be a string, not bytes.

I am not sure if there is an alternate case where this string needs to be `.encode()`d, so please let me know if there is one. I'll either close this PR or figure out how to include that use case